### PR TITLE
Add environment connection function

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ UUID('a5fba242-74c8-4e59-ad89-c1565ee3229c')
 ... conn = btrdb4.Connection("my.server:4410")
 >>> # Connection with an API key. Note port 4411, the secure API
 ... conn = btrdb4.Connection("my.server:4411", apikey="255C59A06BB698681E3580D2")
->>> # Connect using environment variables $BTRDB_ENDPOINTS and $BTRDB_API_KEY
->>> conn = btrdb4.connect()
 >>> b = conn.newContext()
+>>>
+>>> # Connect using environment variables $BTRDB_ENDPOINTS and $BTRDB_API_KEY
+>>> # Note that this returns a context directly rather than a connection.
+>>> b = btrdb4.connect()
 >>>
 >>> # Obtain a stream handle
 ... s = b.streamFromUUID(uu)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ UUID('a5fba242-74c8-4e59-ad89-c1565ee3229c')
 ... conn = btrdb4.Connection("my.server:4410")
 >>> # Connection with an API key. Note port 4411, the secure API
 ... conn = btrdb4.Connection("my.server:4411", apikey="255C59A06BB698681E3580D2")
+>>> # Connect using environment variables $BTRDB_ENDPOINTS and $BTRDB_API_KEY
+>>> conn = btrdb4.connect()
 >>> b = conn.newContext()
 >>>
 >>> # Obtain a stream handle

--- a/btrdb4/__init__.py
+++ b/btrdb4/__init__.py
@@ -39,6 +39,38 @@ from btrdb4.utils import *
 MIN_TIME = -(16 << 56)
 MAX_TIME = 48 << 56
 MAX_POINTWIDTH = 63
+BTRDB_ENDPOINTS = "BTRDB_ENDPOINTS"
+BTRDB_API_KEY = "BTRDB_API_KEY"
+
+
+def connect(addrportstr=None, apikey=None):
+    """
+    Connect to a BTrDB server.
+
+    Parameters
+    ----------
+    addrportstr: str, default=None
+        The address and port of the cluster to connect to, e.g. 192.168.1.1:4411.
+        If set to None will look up the string from the environment variable
+        $BTRDB_ENDPOINTS (recommended).
+
+    apikey: str, default=None
+        The API key use to authenticate requests (optional). If None, the key
+        is looked up from the environment variable $BTRDB_API_KEY.
+
+    Returns
+    -------
+    conn : Connection
+        An instance of the Connection class, used to manage BTrDB interactions.
+    """
+    if addrportstr is None:
+        addrportstr = os.environ.get(BTRDB_ENDPOINTS, default="")
+
+    if apikey is None:
+        apikey = os.environ.get(BTRDB_API_KEY, default=None)
+
+    return Connection(addrportstr, apikey)
+
 
 class Connection(object):
     def __init__(self, addrportstr, apikey=None):

--- a/btrdb4/__init__.py
+++ b/btrdb4/__init__.py
@@ -60,8 +60,8 @@ def connect(addrportstr=None, apikey=None):
 
     Returns
     -------
-    conn : Connection
-        An instance of the Connection class, used to manage BTrDB interactions.
+    db : BTrDB
+        An instance of the BTrDB context to directly interact with the database.
     """
     if addrportstr is None:
         addrportstr = os.environ.get(BTRDB_ENDPOINTS, default="")
@@ -69,7 +69,7 @@ def connect(addrportstr=None, apikey=None):
     if apikey is None:
         apikey = os.environ.get(BTRDB_API_KEY, default=None)
 
-    return Connection(addrportstr, apikey)
+    return Connection(addrportstr, apikey).newContext()
 
 
 class Connection(object):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 setup(
   name = 'btrdb4',
   packages = ['btrdb4'],
-  version = '4.11.1',
+  version = '4.11.2',
   description = "Bindings to interact with the Berkeley Tree Database using gRPC",
   author = 'Sam Kumar, Michael P Andersen',
   author_email = 'samkumar99@gmail.com, michael@steelcode.com',


### PR DESCRIPTION
Preliminary to the btrdb5 release, this PR adds a connection function
that looks up the connection details from the $BTRDB_ENDPOINTS and
$BTRDB_API_KEY environment variables if they are not specified. The
README is updated to reflect this change and the version is bumped to
4.11.2 (from 4.11.1).