### PR TITLE
Testing updates for Python 3.5 and other fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: python
 
+dist: xenial
+
 python:
+  - '3.4'
   - '3.5'
   - '3.6'
+  - '3.7'
 
 before_install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: python
 python:
   - '3.5'
   - '3.6'
-  - '3.7-dev'
-  - '3.8-dev'
 
 before_install:
   - sudo apt-get update

--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -41,10 +41,10 @@ class Stream(object):
         db_args = ('known_to_exist', 'collection', 'tags', 'annotations', 'property_version')
         for key in db_args:
             value = db_values.pop(key, None)
-            setattr(self, f"_{key}", value)
+            setattr(self, "_{}".format(key), value)
         if db_values:
             bad_keys = ", ".join(db_values.keys())
-            raise TypeError(f"got unexpected db_values argument(s) '{bad_keys}'")
+            raise TypeError("got unexpected db_values argument(s) '{}'".format(bad_keys))
 
         self._btrdb = btrdb
         self._uuid = uuid

--- a/btrdb/transformers.py
+++ b/btrdb/transformers.py
@@ -44,8 +44,8 @@ def to_series(stream_set):
     """
     try:
         import pandas as pd
-    except ModuleNotFoundError:
-        raise ModuleNotFoundError("Please install Pandas to use this transformation function.")
+    except ImportError:
+        raise ImportError("Please install Pandas to use this transformation function.")
 
     result = []
     for output in stream_set.values():
@@ -64,8 +64,8 @@ def to_dataframe(stream_set, columns=None):
     """
     try:
         import pandas as pd
-    except ModuleNotFoundError:
-        raise Exception("Please install Pandas to use this transformation function.")
+    except ImportError:
+        raise ImportError("Please install Pandas to use this transformation function.")
 
     stream_names = _stream_names(stream_set)
     columns = columns if columns else ["time"] + list(stream_names)
@@ -78,8 +78,8 @@ def to_array(stream_set):
     """
     try:
         import numpy as np
-    except ModuleNotFoundError:
-        raise Exception("...")
+    except ImportError:
+        raise ImportError("Please install Numpy to use this transformation function.")
 
     return tuple([np.array(output) for output in stream_set.values()])
 
@@ -119,8 +119,8 @@ def to_table(stream_set):
     """
     try:
         from tabulate import tabulate
-    except ModuleNotFoundError:
-        raise Exception("...")
+    except ImportError:
+        raise ImportError("Please install tabulate to use this transformation function.")
 
     return tabulate(stream_set.to_dict(), headers="keys")
 

--- a/btrdb/utils/timez.py
+++ b/btrdb/utils/timez.py
@@ -56,7 +56,7 @@ def to_nanoseconds(val):
         import numpy as np
         if isinstance(val, np.datetime64):
             val = val.astype(datetime.datetime)
-    except ModuleNotFoundError:
+    except ImportError:
         pass
 
     if isinstance(val, str):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 # GRPC / Protobuff related
 grpcio==1.12.1
 grpcio-tools==1.12.1
+
+# Time related utils
+pytz

--- a/tests/btrdb/test_stream.py
+++ b/tests/btrdb/test_stream.py
@@ -194,7 +194,7 @@ class TestStream(object):
         stream.refresh_metadata = Mock(return_value=True)
 
         assert stream.exists()
-        stream.refresh_metadata.assert_called()
+        assert stream.refresh_metadata.call_count == 1
 
 
     def test_exists_returns_false_on_404(self):
@@ -206,7 +206,7 @@ class TestStream(object):
         stream.refresh_metadata = Mock(side_effect=BTrDBError(code=404, msg="hello", mash=""))
 
         assert stream.exists() == False
-        stream.refresh_metadata.assert_called()
+        assert stream.refresh_metadata.call_count == 1
 
 
     def test_exists_passes_other_errors(self):
@@ -219,7 +219,7 @@ class TestStream(object):
 
         with pytest.raises(ValueError):
             stream.exists()
-        stream.refresh_metadata.assert_called()
+        assert stream.refresh_metadata.call_count == 1
 
 
     ##########################################################################
@@ -263,7 +263,7 @@ class TestStream(object):
         stream.refresh_metadata = Mock()
 
         stream.tags(refresh=True)
-        stream.refresh_metadata.assert_called()
+        assert stream.refresh_metadata.call_count == 1
 
 
     def test_annotations_returns_copy_of_value(self):
@@ -306,7 +306,7 @@ class TestStream(object):
         stream.refresh_metadata = Mock()
 
         stream.annotations(refresh=True)
-        stream.refresh_metadata.assert_called()
+        assert stream.refresh_metadata.call_count == 1
 
 
     ##########################################################################

--- a/tests/btrdb/test_stream.py
+++ b/tests/btrdb/test_stream.py
@@ -405,7 +405,7 @@ class TestStream(object):
         stream = Stream(btrdb=BTrDB(endpoint), uuid=uu)
         endpoint.nearest = Mock(return_value=(RawPointProto(time=100, value=1.0), 42))
 
-        with freeze_time("2018-01-01 12:00:00"):
+        with freeze_time("2018-01-01 12:00:00 -0000"):
             point, ver = stream.latest()
 
         assert (point, ver) == (RawPoint(100, 1.0), 42)
@@ -421,7 +421,7 @@ class TestStream(object):
         stream = Stream(btrdb=BTrDB(endpoint), uuid=uu)
         endpoint.nearest = Mock(side_effect=Exception())
 
-        with freeze_time("2018-01-01 12:00:00"):
+        with freeze_time("2018-01-01 12:00:00 -0000"):
             assert stream.latest() is None
         endpoint.nearest.assert_called_once_with(uu, 1514826000000000000, 0, True)
 

--- a/tests/btrdb/test_stream.py
+++ b/tests/btrdb/test_stream.py
@@ -16,6 +16,8 @@ Testing package for the btrdb stream module
 ##########################################################################
 
 import uuid
+import pytz
+import datetime
 import pytest
 from unittest.mock import Mock, PropertyMock
 from freezegun import freeze_time
@@ -405,7 +407,7 @@ class TestStream(object):
         stream = Stream(btrdb=BTrDB(endpoint), uuid=uu)
         endpoint.nearest = Mock(return_value=(RawPointProto(time=100, value=1.0), 42))
 
-        with freeze_time("2018-01-01 12:00:00 -0000"):
+        with freeze_time("2018-01-01 12:00:00", tz_offset=0):
             point, ver = stream.latest()
 
         assert (point, ver) == (RawPoint(100, 1.0), 42)
@@ -421,7 +423,7 @@ class TestStream(object):
         stream = Stream(btrdb=BTrDB(endpoint), uuid=uu)
         endpoint.nearest = Mock(side_effect=Exception())
 
-        with freeze_time("2018-01-01 12:00:00 -0000"):
+        with freeze_time(datetime.datetime(2018,1,1,12, tzinfo=pytz.utc)):
             assert stream.latest() is None
         endpoint.nearest.assert_called_once_with(uu, 1514826000000000000, 0, True)
 

--- a/tests/btrdb/test_stream.py
+++ b/tests/btrdb/test_stream.py
@@ -20,7 +20,7 @@ import pytz
 import datetime
 import pytest
 from unittest.mock import Mock, PropertyMock
-from freezegun import freeze_time
+from unittest.mock import patch
 
 from btrdb.stream import Stream, StreamSet, StreamFilter, INSERT_BATCH_SIZE
 from btrdb.point import RawPoint, StatPoint
@@ -194,7 +194,7 @@ class TestStream(object):
         stream.refresh_metadata = Mock(return_value=True)
 
         assert stream.exists()
-        stream.refresh_metadata.assert_called_once()
+        stream.refresh_metadata.assert_called()
 
 
     def test_exists_returns_false_on_404(self):
@@ -206,7 +206,7 @@ class TestStream(object):
         stream.refresh_metadata = Mock(side_effect=BTrDBError(code=404, msg="hello", mash=""))
 
         assert stream.exists() == False
-        stream.refresh_metadata.assert_called_once()
+        stream.refresh_metadata.assert_called()
 
 
     def test_exists_passes_other_errors(self):
@@ -219,7 +219,7 @@ class TestStream(object):
 
         with pytest.raises(ValueError):
             stream.exists()
-        stream.refresh_metadata.assert_called_once()
+        stream.refresh_metadata.assert_called()
 
 
     ##########################################################################
@@ -263,7 +263,7 @@ class TestStream(object):
         stream.refresh_metadata = Mock()
 
         stream.tags(refresh=True)
-        stream.refresh_metadata.assert_called_once()
+        stream.refresh_metadata.assert_called()
 
 
     def test_annotations_returns_copy_of_value(self):
@@ -306,7 +306,7 @@ class TestStream(object):
         stream.refresh_metadata = Mock()
 
         stream.annotations(refresh=True)
-        stream.refresh_metadata.assert_called_once()
+        stream.refresh_metadata.assert_called()
 
 
     ##########################################################################
@@ -398,7 +398,8 @@ class TestStream(object):
         endpoint.nearest.assert_called_once_with(uu, 0, 0, False)
 
 
-    def test_latest(self):
+    @patch("btrdb.stream.currently_as_ns")
+    def test_latest(self, mocked):
         """
         Assert latest calls Endpoint.nearest
         """
@@ -406,15 +407,16 @@ class TestStream(object):
         endpoint = Mock(Endpoint)
         stream = Stream(btrdb=BTrDB(endpoint), uuid=uu)
         endpoint.nearest = Mock(return_value=(RawPointProto(time=100, value=1.0), 42))
-
-        with freeze_time("2018-01-01 12:00:00", tz_offset=0):
-            point, ver = stream.latest()
+        ns_fake_time = 1514808000000000000
+        mocked.return_value = ns_fake_time
+        point, ver = stream.latest()
 
         assert (point, ver) == (RawPoint(100, 1.0), 42)
-        endpoint.nearest.assert_called_once_with(uu, 1514826000000000000, 0, True)
+        endpoint.nearest.assert_called_once_with(uu, ns_fake_time, 0, True)
 
 
-    def test_latest_swallows_exception(self):
+    @patch("btrdb.stream.currently_as_ns")
+    def test_latest_swallows_exception(self, mocked):
         """
         Assert latest returns None when endpoint throws exception
         """
@@ -422,10 +424,11 @@ class TestStream(object):
         endpoint = Mock(Endpoint)
         stream = Stream(btrdb=BTrDB(endpoint), uuid=uu)
         endpoint.nearest = Mock(side_effect=Exception())
+        ns_fake_time = 1514808000000000000
+        mocked.return_value = ns_fake_time
 
-        with freeze_time(datetime.datetime(2018,1,1,12, tzinfo=pytz.utc)):
-            assert stream.latest() is None
-        endpoint.nearest.assert_called_once_with(uu, 1514826000000000000, 0, True)
+        assert stream.latest() is None
+        endpoint.nearest.assert_called_once_with(uu, ns_fake_time, 0, True)
 
 
     ##########################################################################

--- a/tests/btrdb/utils/test_timez.py
+++ b/tests/btrdb/utils/test_timez.py
@@ -36,7 +36,7 @@ class TestCurrentlyAsNs(object):
         Assert currently_as_ns returns correct value
         """
         expected = int(datetime.datetime(2018,1,1,12).timestamp() * 1e9)
-        with freeze_time("2018-01-01 12:00:00"):
+        with freeze_time("2018-01-01 12:00:00 -0000"):
             assert currently_as_ns() == expected
 
 


### PR DESCRIPTION
This PR fixes various tests and provides for python 3.5 compatibility in the current `develop` branch.

- `ModuleNotFoundError` replaced with `ImportError` for python 3.5
- Removes `3.8-dev` from Travis config as it is not yet available 
- Adds `3.7` to travis and forces Ubuntu Xenial distro (16.04)
- Replaces `f""` format strings for python 3.5
- Replaces `assert_called_once` for python 3.5
- Fixes `freezegun` directive in `test/requirements.txt`
- Replaces `freeze_time` with `patch` due to timezone error in stream tests